### PR TITLE
Download the latest (as of the writing) version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _share/
 blib/
 /Alien-Librdkafka-*
 *.bak
+/_alien

--- a/Build.PL
+++ b/Build.PL
@@ -16,14 +16,14 @@ my $builder = Alien::Base::ModuleBuild->new(
     alien_autoconf_with_pic => 0,
     alien_name => 'rdkafka',
     alien_build_commands => [
-      '%c --prefix=%s --enable-static',
+      '%c --prefix=%s',
       'make',
     ],
     alien_isolate_dynamic => 1,
     alien_repository => {
         protocol => 'https',
-        exact_filename => 'https://github.com/edenhill/librdkafka/archive/v0.11.6.tar.gz',
-        exact_version => 'v0.11.6',
+        exact_filename => 'https://github.com/edenhill/librdkafka/archive/v1.1.0.tar.gz',
+        exact_version => 'v1.1.0',
     },
     alien_version_check => '%{pkg_config} --atleast-version 0.9.3 %n && %{pkg_config} --modversion %n',
     meta_merge => {

--- a/maint/cip-test
+++ b/maint/cip-test
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+perl Build.PL
+./Build
+./Build test verbose=1
+./Build install
+
+cpanm -v Kafka::Librd


### PR DESCRIPTION
as of 12 days ago this is v1.1.0

Also remove --enable-static from the configure line.  Normally this option would build a static library, however, configure does not seem to be based on autoconf, and its behavior is actually linking AGAINST static libraries instead.  On some platforms this can cause a link fail if the system libraries
aren't built with -fPIC / -fpic

```
 /usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/libz.a(deflate.o): relocation R_X86_64_PC32 against symbol `z_errmsg' can not be used when making a shared object; recompile with -fPIC
```

This was not the case in the v0.11.6.  Without --enable-static it still builds a .a file which can be used by XS and a .so file which can be used by FFI.